### PR TITLE
Fix typo "Round Time Trip" -> "Round Trip Time"

### DIFF
--- a/renet2_visualizer/src/lib.rs
+++ b/renet2_visualizer/src/lib.rs
@@ -163,12 +163,12 @@ impl<const N: usize> RenetClientVisualizer<N> {
         );
     }
 
-    /// Draws only the Round Time Trip metric.
+    /// Draws only the Round Trip Time metric.
     pub fn draw_rtt(&self, ui: &mut egui::Ui) {
         show_graph(
             ui,
             &self.style,
-            "Round Time Trip (ms)",
+            "Round Trip Time (ms)",
             TextFormat::Normal,
             TopValue::SuggestedValues([32., 64., 128., 256., 512.]),
             self.rtt.as_vec(),


### PR DESCRIPTION
This PR fixes a typo I've gotten tired looking at :)

------------------------

Hey @UkoeHB ! I started using renet2 recently and have been enjoying it. Seeing as this is the first PR on your repo (that I know of), I don't know how much you intend to fork away from the original renet & whether you are taking contributions, so here's a small one to begin with.