### PR TITLE
Fix version mismatch among h3 dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 Cargo.lock
 /.idea
 .vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ members = [
     "renet2_steam",
     "renetcode2",
 ]
+exclude = [
+    "examples/echo_client_wt",
+]
 resolver = "2"

--- a/renet2/Cargo.toml
+++ b/renet2/Cargo.toml
@@ -96,11 +96,11 @@ quinn = { version = "0.10", optional = true, default-features = false, features 
     "tls-rustls",
     "ring",
 ] }
-h3-quinn = { version = "0.0.5", optional = true, git = "https://github.com/hyperium/h3" }
-h3-webtransport = { version = "0.1", optional = true, git = "https://github.com/hyperium/h3" }
+h3-quinn = { tag = "h3-v0.0.4", optional = true, git = "https://github.com/hyperium/h3" }
+h3-webtransport = { version = "0.1", tag = "h3-v0.0.4", optional = true, git = "https://github.com/hyperium/h3" }
 tokio = { version = "1.32", optional = true, features = ["full"] }
 http = { version = "1.0", optional = true }
-h3 = { version = "0.0.4", optional = true, git = "https://github.com/hyperium/h3", features = [
+h3 = { tag = "h3-v0.0.4", optional = true, git = "https://github.com/hyperium/h3", features = [
     "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 ] }
 time = { version = "0.3", optional = true }


### PR DESCRIPTION
This fixes the building issues with the h3 dependencies, caused by a version mismatch between them. As a fix I have set to the git tag `h3-v0.0.4` to all of them, which seems to be the last tag before h3 upgraded `quinn-rs` to `0.11`, which brings some breaking changes with `rustls` also upgrading to `0.23`.

On another note, `wasm-pack build` failed for me in `echo_client_wt` because cargo thought it was part of the workspace, so I excluded it in the root toml.

This closes #10