### PR TITLE
Update to Replicon 0.32

### DIFF
--- a/bevy_replicon_renet2/Cargo.toml
+++ b/bevy_replicon_renet2/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 
 [dependencies]
-bevy_replicon = { version = "0.31", default-features = false }
+bevy_replicon = { version = "0.32", default-features = false }
 bevy_renet2 = { path = "../bevy_renet2", version = "0.6.0", default-features = false }
 bevy = { version = "0.15", default-features = false }
 

--- a/bevy_replicon_renet2/Cargo.toml
+++ b/bevy_replicon_renet2/Cargo.toml
@@ -25,7 +25,6 @@ rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 bevy_replicon = { version = "0.31", default-features = false }
 bevy_renet2 = { path = "../bevy_renet2", version = "0.6.0", default-features = false }
 bevy = { version = "0.15", default-features = false }
-serde = "1.0"
 
 [dev-dependencies]
 clap = { version = "4.1", features = ["derive"] }
@@ -39,6 +38,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "x11",
   "default_font",
 ] }
+serde = "1.0"
 log = "0.4"
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "std", "tracing-log" ] }
 

--- a/bevy_replicon_renet2/README.md
+++ b/bevy_replicon_renet2/README.md
@@ -8,6 +8,7 @@ Run tests with `cargo test --features native_transport,client,server`.
 
 | bevy_replicon_renet2 | bevy_renet2 | bevy_replicon | bevy   |
 |----------------------|-------------|---------------|--------|
+| 0.6                  | 0.6         | 0.31          | 0.15   |
 | 0.5                  | 0.5         | 0.30          | 0.15   |
 | 0.4                  | 0.4         | 0.30          | 0.15   |
 | 0.3                  | 0.3         | 0.30          | 0.15   |

--- a/bevy_replicon_renet2/examples/simple_box.rs
+++ b/bevy_replicon_renet2/examples/simple_box.rs
@@ -43,7 +43,7 @@ impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate::<BoxPosition>()
             .replicate::<PlayerBox>()
-            .add_client_trigger::<MoveBox>(ChannelKind::Ordered)
+            .add_client_trigger::<MoveBox>(Channel::Ordered)
             .add_observer(spawn_clients)
             .add_observer(despawn_clients)
             .add_observer(apply_movement)
@@ -63,8 +63,8 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
         Cli::Server { port } => {
             info!("starting server at port {port}");
             let server = RenetServer::new(ConnectionConfig::from_channels(
-                channels.get_server_configs(),
-                channels.get_client_configs(),
+                channels.server_configs(),
+                channels.client_configs(),
             ));
 
             let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
@@ -95,7 +95,7 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
         Cli::Client { port, ip } => {
             info!("connecting to {ip}:{port}");
             let client = RenetClient::new(
-                ConnectionConfig::from_channels(channels.get_server_configs(), channels.get_client_configs()),
+                ConnectionConfig::from_channels(channels.server_configs(), channels.client_configs()),
                 false,
             );
 

--- a/bevy_replicon_renet2/examples/tic_tac_toe.rs
+++ b/bevy_replicon_renet2/examples/tic_tac_toe.rs
@@ -50,9 +50,9 @@ impl Plugin for TicTacToePlugin {
             .init_resource::<SymbolFont>()
             .init_resource::<TurnSymbol>()
             .replicate::<Symbol>()
-            .add_client_trigger::<CellPick>(ChannelKind::Ordered)
-            .add_client_trigger::<MapCells>(ChannelKind::Ordered)
-            .add_server_trigger::<MakeLocal>(ChannelKind::Ordered)
+            .add_client_trigger::<CellPick>(Channel::Ordered)
+            .add_client_trigger::<MapCells>(Channel::Ordered)
+            .add_server_trigger::<MakeLocal>(Channel::Ordered)
             .insert_resource(ClearColor(BACKGROUND_COLOR))
             .add_observer(disconnect_by_client)
             .add_observer(init_client)
@@ -111,8 +111,8 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
         Cli::Server { port, symbol } => {
             info!("starting server as {symbol} at port {port}");
             let server = RenetServer::new(ConnectionConfig::from_channels(
-                channels.get_server_configs(),
-                channels.get_client_configs(),
+                channels.server_configs(),
+                channels.client_configs(),
             ));
 
             let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
@@ -134,7 +134,7 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
         Cli::Client { port, ip } => {
             info!("connecting to {ip}:{port}");
             let client = RenetClient::new(
-                ConnectionConfig::from_channels(channels.get_server_configs(), channels.get_client_configs()),
+                ConnectionConfig::from_channels(channels.server_configs(), channels.client_configs()),
                 false,
             );
 

--- a/bevy_replicon_renet2/src/client/plugin.rs
+++ b/bevy_replicon_renet2/src/client/plugin.rs
@@ -69,7 +69,7 @@ impl RepliconRenetClientPlugin {
 
     fn send_packets(mut renet_client: ResMut<RenetClient>, mut replicon_client: ResMut<RepliconClient>) {
         for (channel_id, message) in replicon_client.drain_sent() {
-            renet_client.send_message(channel_id, message)
+            renet_client.send_message(channel_id as u8, message)
         }
     }
 }

--- a/bevy_replicon_renet2/src/lib.rs
+++ b/bevy_replicon_renet2/src/lib.rs
@@ -1,16 +1,20 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 /*!
-Provides integration for [`bevy_replicon`](https://docs.rs/bevy_replicon) for `bevy_renet2`.
+Provides integration for [`bevy_replicon`](https://docs.rs/bevy_replicon) for [`bevy_renet2`](https://docs.rs/bevy_renet2).
 
 # Getting started
 
-This guide assumes that you have already read [quick start guide](https://docs.rs/bevy_replicon#quick-start) from `bevy_replicon`.
+This guide assumes that you have already read the [quick start guide](https://docs.rs/bevy_replicon#quick-start)
+for `bevy_replicon`.
 
-All Renet API is re-exported from this plugin, you don't need to include `bevy_renet` or `renet` to your `Cargo.toml`.
+## Modules
 
-Renet by default uses the netcode transport which is re-exported by the `transport` feature. If you want to use other transports, you can disable it.
+Renet2 API is re-exported from this crate under [`renet2`] module. Features from `bevy_renet2` are exposed,
+which also re-export the corresponding transport modules. Like in `bevy_renet2`, the netcode
+transport is enabled by default.
 
-## Initialization
+So you don't need to include `bevy_renet2` or `renet2` in your `Cargo.toml`.
+
+## Plugins
 
 Add [`RepliconRenetPlugins`] along with [`RepliconPlugins`](bevy_replicon::prelude::RepliconPlugins):
 
@@ -23,40 +27,66 @@ let mut app = App::new();
 app.add_plugins((MinimalPlugins, RepliconPlugins, RepliconRenetPlugins));
 ```
 
-Plugins in [`RepliconRenetPlugins`] automatically add `renet2` plugins, you don't need to add them.
+Similar to Replicon, we provide `client` and `server` features. These automatically enable the corresponding
+features in `bevy_replicon`.
 
-If the `transport` feature is enabled, netcode plugins will also be automatically added.
+The plugins in [`RepliconRenetPlugins`] automatically include the `renet2` plugins, so you don't need to add
+them manually. When a transport feature is enabled, the netcode plugins will also be added automatically.
 
 ## Server and client creation
 
-To connect to the server or create it, you need to initialize the
-[`RenetClient`](renet2::RenetClient) and `renet2_netcode::NetcodeClientTransport` **or**
-[`RenetServer`](renet2::RenetServer) and `renet2_netcode::NetcodeServerTransport` resources from Renet.
+Just like with regular `bevy_renet2`, you need to create the
+[`RenetClient`](renet2::RenetClient) and [`NetcodeClientTransport`](netcode::NetcodeClientTransport) **or**
+[`RenetServer`](renet2::RenetServer) and [`NetcodeServerTransport`](netcode::NetcodeServerTransport)
+resources from Renet.
 
-Never insert client and server resources in the same app for single-player, it will cause a replication loop.
+This crate will automatically manage their integration with Replicon.
 
-This crate provides the [`RenetChannelsExt`] extension trait to conveniently convert channels
-from the [`RepliconChannels`] resource into renet2 channels.
-When creating a server or client you need to use a [`ConnectionConfig`](renet2::ConnectionConfig)
-from [`renet2`], which can be initialized like this:
+<div class="warning">
+
+Never insert client and server resources in the same app, it will cause a replication loop.
+See the Replicon's quick start guide for more details.
+
+</div>
+
+The only Replicon-specific part is channels. You need to get them from the [`RepliconChannels`](bevy_replicon::prelude::RepliconChannels) resource.
+This crate provides the [`RenetChannelsExt`] extension trait to conveniently create renet channels from it:
 
 ```
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use bevy_replicon_renet2::{renet2::ConnectionConfig, RenetChannelsExt, RepliconRenetPlugins};
+use bevy_replicon_renet2::{renet2::ConnectionConfig, RenetChannelsExt};
 
-# let mut app = App::new();
-# app.add_plugins(RepliconPlugins);
-let channels = app.world().resource::<RepliconChannels>();
-let connection_config = ConnectionConfig::from_channels(
-    channels.get_server_configs(),
-    channels.get_client_configs(),
-);
+fn init(channels: Res<RepliconChannels>) {
+    let connection_config = ConnectionConfig::from_channels(
+        channels.server_configs(),
+        channels.client_configs(),
+    );
+
+    // Use this config for `RenetServer` or `RenetClient`
+}
 ```
 
-For a full example of how to initialize a server or client see the example in the
-repository.
+For a full example of how to initialize a server or client see examples in the repository.
+
+<div class="warning">
+
+Channels need to be obtained only **after** registering all replication components and remote events.
+
+</div>
+
+## Replicon conditions
+
+The crate updates the running state of [`RepliconServer`](bevy_replicon::prelude::RepliconServer) and connection state of [`RepliconClient`](bevy_replicon::prelude::RepliconClient)
+based on the states of [`RenetServer`](renet2::RenetServer) and [`RenetClient`](renet2::RenetServer)
+in [`PreUpdate`](bevy::prelude::PreUpdate).
+
+This means that [Replicon conditions](bevy_replicon::shared::common_conditions) won't work in schedules
+like [`Startup`](bevy::prelude::Startup). As a workaround, you can directly check if renet's resources are present. This may be resolved
+in the future once we have [observers for resources](https://github.com/bevyengine/bevy/issues/12231)
+to immediately react to changes.
 */
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use bevy_renet2::prelude as renet2;
 

--- a/bevy_replicon_renet2/src/server/plugin.rs
+++ b/bevy_replicon_renet2/src/server/plugin.rs
@@ -54,7 +54,7 @@ impl RepliconRenetServerPlugin {
                     let client_entity = commands
                       .spawn((
                           ConnectedClient {
-                              // From https://github.com/lucaspoffo/renet/blob/master/renet/src/packet.rs#L7
+                              // From https://github.com/UkoeHB/renet2/blob/main/renet2/src/packet.rs#L7
                               max_size: 1200,
                           },
                           network_id,

--- a/bevy_replicon_renet2/src/server/plugin.rs
+++ b/bevy_replicon_renet2/src/server/plugin.rs
@@ -4,8 +4,8 @@ use crate::renet2::{RenetReceive, RenetSend, RenetServer, RenetServerPlugin};
 use bevy::prelude::*;
 use bevy_renet2::prelude::ServerEvent;
 use bevy_replicon::{
-    core::connected_client::{ClientId, ClientIdMap},
     prelude::*,
+    shared::backend::connected_client::{NetworkId, NetworkIdMap},
 };
 
 pub struct RepliconRenetServerPlugin;
@@ -46,23 +46,30 @@ impl RepliconRenetServerPlugin {
         server.set_running(false);
     }
 
-    fn forward_server_events(mut commands: Commands, mut server_events: EventReader<ServerEvent>, client_map: Res<ClientIdMap>) {
+    fn forward_server_events(mut commands: Commands, mut server_events: EventReader<ServerEvent>, network_map: Res<NetworkIdMap>,) {
         for event in server_events.read() {
             match event {
                 ServerEvent::ClientConnected { client_id } => {
-                    let client_id = ClientId::new(*client_id);
-                    const MAX_SIZE: usize = 1200; // From https://github.com/UkoeHB/renet2/blob/main/renet2/src/packet.rs#L7
-                    let client_entity = commands.spawn(ConnectedClient::new(client_id, MAX_SIZE)).id();
-                    debug!("connecting `{client_entity}` with `{client_id:?}`");
+                    let network_id = NetworkId::new(*client_id);
+                    let client_entity = commands
+                      .spawn((
+                          ConnectedClient {
+                              // From https://github.com/lucaspoffo/renet/blob/master/renet/src/packet.rs#L7
+                              max_size: 1200,
+                          },
+                          network_id,
+                      ))
+                      .id();
+                    debug!("connecting `{client_entity}` with `{network_id:?}`");
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {
-                    let client_id = ClientId::new(*client_id);
-                    let client_entity = *client_map
-                        .get(&client_id)
-                        .expect("clients should be connected before disconnection");
+                    let network_id = NetworkId::new(*client_id);
+                    let client_entity = *network_map
+                      .get(&network_id)
+                      .expect("clients should be connected before disconnection");
 
                     commands.entity(client_entity).despawn();
-                    debug!("disconnecting `{client_entity}` with `{client_id:?}`: {reason}");
+                    debug!("disconnecting `{client_entity}` with `{network_id:?}`: {reason}");
                 }
             };
         }
@@ -72,17 +79,22 @@ impl RepliconRenetServerPlugin {
         channels: Res<RepliconChannels>,
         mut renet_server: ResMut<RenetServer>,
         mut replicon_server: ResMut<RepliconServer>,
-        mut clients: Query<(Entity, &ConnectedClient, &mut NetworkStats)>,
+        mut clients: Query<(Entity, &NetworkId, &mut NetworkStats)>,
     ) {
-        for (client_entity, client, mut stats) in &mut clients {
+        for (client_entity, network_id, mut stats) in &mut clients {
             for channel_id in 0..channels.client_channels().len() as u8 {
-                while let Some(message) = renet_server.receive_message(client.id().get(), channel_id) {
+                while let Some(message) = renet_server.receive_message(network_id.get(), channel_id)
+                {
+                    trace!(
+                        "forwarding {} received bytes over channel {channel_id}",
+                        message.len()
+                    );
                     replicon_server.insert_received(client_entity, channel_id, message);
                 }
             }
 
             // Renet events reading runs in parallel, so the client might have been disconnected.
-            if let Ok(info) = renet_server.network_info(client.id().get()) {
+            if let Ok(info) = renet_server.network_info(network_id.get()) {
                 stats.rtt = info.rtt;
                 stats.packet_loss = info.packet_loss;
                 stats.sent_bps = info.bytes_sent_per_second;
@@ -91,12 +103,20 @@ impl RepliconRenetServerPlugin {
         }
     }
 
-    fn send_packets(mut renet_server: ResMut<RenetServer>, mut replicon_server: ResMut<RepliconServer>, clients: Query<&ConnectedClient>) {
+    fn send_packets(
+        mut renet_server: ResMut<RenetServer>,
+        mut replicon_server: ResMut<RepliconServer>,
+        clients: Query<&NetworkId>,
+    ) {
         for (client_entity, channel_id, message) in replicon_server.drain_sent() {
-            let client = clients
-                .get(client_entity)
-                .expect("messages should be sent only to connected clients");
-            renet_server.send_message(client.id().get(), channel_id, message)
+            trace!(
+                "forwarding {} sent bytes over channel {channel_id}",
+                message.len()
+            );
+            let network_id = clients
+              .get(client_entity)
+              .expect("messages should be sent only to connected clients");
+            renet_server.send_message(network_id.get(), channel_id as u8, message)
         }
     }
 }

--- a/bevy_replicon_renet2/tests/transport.rs
+++ b/bevy_replicon_renet2/tests/transport.rs
@@ -97,7 +97,7 @@ fn server_event() {
             }),
             RepliconRenetPlugins,
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .add_server_event::<DummyEvent>(Channel::Ordered)
         .finish();
     }
 
@@ -128,7 +128,7 @@ fn client_event() {
             }),
             RepliconRenetPlugins,
         ))
-        .add_client_event::<DummyEvent>(ChannelKind::Ordered)
+        .add_client_event::<DummyEvent>(Channel::Ordered)
         .finish();
     }
 
@@ -154,7 +154,7 @@ fn setup_client(app: &mut App, client_id: u64, port: u16) {
     let channels = app.world().resource::<RepliconChannels>();
 
     let server_channels_config = channels.get_server_configs();
-    let client_channels_config = channels.get_client_configs();
+    let client_channels_config = channels.client_configs();
 
     let client = RenetClient::new(
         ConnectionConfig::from_channels(server_channels_config, client_channels_config),
@@ -169,7 +169,7 @@ fn setup_server(app: &mut App, max_clients: usize) -> u16 {
     let channels = app.world().resource::<RepliconChannels>();
 
     let server_channels_config = channels.get_server_configs();
-    let client_channels_config = channels.get_client_configs();
+    let client_channels_config = channels.client_configs();
 
     let server = RenetServer::new(ConnectionConfig::from_channels(server_channels_config, client_channels_config));
     let transport = create_server_transport(max_clients);


### PR DESCRIPTION
Based on:

- https://github.com/projectharmonia/bevy_replicon_renet/commit/8322512e7655d4f2ce3c5e56dd3467f0c736e3ee (base update)
- https://github.com/projectharmonia/bevy_replicon_renet/commit/f7d82db5207c1c6d7911068a3885b21521ab00bb (renaming of channel getters)
- https://github.com/projectharmonia/bevy_replicon_renet/commit/75fc8c619562989f3ba3d392395e43c03d5b905d (I mistakenly copied Shatur's mistake, and hereby copy their fix as well 😉)

Also:
- took the doc improvements from `bevy_replicon_renet`, and translated/migrated it to this crate, but was not very confident about the docs on the reexport & feature flags. Could you please double check that?
- updated the compatibility table to include 0.31 compatibility with the 0.6 release.
