### PR TITLE
Activate bevy gizmos render feature in dev

### DIFF
--- a/bevy_replicon_renet2/Cargo.toml
+++ b/bevy_replicon_renet2/Cargo.toml
@@ -35,6 +35,7 @@ bevy = { version = "0.18", default-features = false, features = [
   "bevy_gizmos",
   "bevy_state",
   "bevy_text",
+  "bevy_gizmos_render",
   "bevy_ui_render",
   "bevy_window",
   "default_font",


### PR DESCRIPTION
I tried to run the `bevy_replicon_renet2/examples/simple_box.rs` example, but the gizmos representing the players wouldn't show up. Seems like bevy requires that the `bevy_gizmos_render` feature gets enabled explicitly [to bring the logic in](https://github.com/bevyengine/bevy/blob/fcabe2a01b8d4b9e654f539f064bd55ebe67c129/Cargo.toml#L375), as no "feature group" is being used. This PR adds it.