### PR TITLE
Fix Bevy Demo

### DIFF
--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/bin/server.rs"
 
 [features]
 netcode = ["bevy_renet2/netcode", "bevy_renet2/native_transport"]
-steam = ["bevy_renet2/steam"]
+steam = ["bevy_renet2/steam", "dep:steamworks"]
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [


### PR DESCRIPTION
As of now the demo will not work even with
`cargo run --bin server --features steam`

This change ensures that the demo will work out of the box.

I am not sure how you want to handle this either with this PR or in the versioning work that is to be done. I just added this for your convince.