### PR TITLE
Update to support Bevy 0.19

### DIFF
--- a/bevy_renet2/Cargo.toml
+++ b/bevy_renet2/Cargo.toml
@@ -31,9 +31,9 @@ name = "simple"
 required-features = ["serde", "netcode"]
 
 [dependencies]
-bevy_app = { version = "0.18", default-features = false }
-bevy_ecs = { version = "0.18", default-features = false }
-bevy_time = { version = "0.18", default-features = false }
+bevy_app = { version = "0.19", default-features = false }
+bevy_ecs = { version = "0.19", default-features = false }
+bevy_time = { version = "0.19", default-features = false }
 renet2 = { path = "../renet2", version = "0.15.0", default-features = false, features = [
   "bevy",
 ] }
@@ -46,7 +46,7 @@ renet2_steam = { path = "../renet2_steam", version = "0.15.0", optional = true, 
 steamworks = { version = "0.13", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_mesh",
   "bevy_render",

--- a/bevy_renet2/examples/simple.rs
+++ b/bevy_renet2/examples/simple.rs
@@ -18,7 +18,7 @@ const PROTOCOL_ID: u64 = 7;
 
 const PLAYER_MOVE_SPEED: f32 = 5.0;
 
-#[derive(Debug, Default, Serialize, Deserialize, Component, Resource)]
+#[derive(Debug, Default, Serialize, Deserialize, Component)]
 struct PlayerInput {
     up: bool,
     down: bool,
@@ -108,7 +108,6 @@ fn main() {
     } else {
         app.add_plugins(RenetClientPlugin);
         app.add_plugins(NetcodeClientPlugin);
-        app.init_resource::<PlayerInput>();
         let (client, transport) = new_renet_client();
         app.insert_resource(client);
         app.insert_resource(transport);
@@ -117,6 +116,7 @@ fn main() {
             Update,
             (player_input, client_send_input, client_sync_players).run_if(client_connected),
         );
+        app.add_systems(Startup, setup_player_input);
     }
 
     app.add_systems(Startup, setup);
@@ -237,6 +237,10 @@ fn client_sync_players(
     }
 }
 
+fn setup_player_input(mut commands: Commands) {
+    commands.spawn(PlayerInput::default());
+}
+
 /// set up a simple 3D scene
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
     // plane
@@ -248,7 +252,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials
     commands.spawn((
         PointLight {
             intensity: 300000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..Default::default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),
@@ -260,14 +264,14 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials
     ));
 }
 
-fn player_input(keyboard_input: Res<ButtonInput<KeyCode>>, mut player_input: ResMut<PlayerInput>) {
+fn player_input(keyboard_input: Res<ButtonInput<KeyCode>>, mut player_input: Single<&mut PlayerInput>) {
     player_input.left = keyboard_input.pressed(KeyCode::KeyA) || keyboard_input.pressed(KeyCode::ArrowLeft);
     player_input.right = keyboard_input.pressed(KeyCode::KeyD) || keyboard_input.pressed(KeyCode::ArrowRight);
     player_input.up = keyboard_input.pressed(KeyCode::KeyW) || keyboard_input.pressed(KeyCode::ArrowUp);
     player_input.down = keyboard_input.pressed(KeyCode::KeyS) || keyboard_input.pressed(KeyCode::ArrowDown);
 }
 
-fn client_send_input(player_input: Res<PlayerInput>, mut client: ResMut<RenetClient>) {
+fn client_send_input(player_input: Single<&PlayerInput>, mut client: ResMut<RenetClient>) {
     let input_message = bincode::serialize(&*player_input).unwrap();
 
     client.send_message(DefaultChannel::ReliableOrdered, input_message);

--- a/bevy_renet2/src/run_conditions.rs
+++ b/bevy_renet2/src/run_conditions.rs
@@ -43,7 +43,7 @@ pub fn client_should_update() -> impl SystemCondition<()> {
     // (just_disconnected || !disconnected) && exists<RenetClient>
     IntoSystem::into_system(
         client_just_disconnected
-            .or(not(client_disconnected))
-            .and(resource_exists::<RenetClient>),
+            .or_else(not(client_disconnected))
+            .and_then(resource_exists::<RenetClient>),
     )
 }

--- a/bevy_replicon_renet2/Cargo.toml
+++ b/bevy_replicon_renet2/Cargo.toml
@@ -22,16 +22,16 @@ all-features = true
 rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 
 [dependencies]
-bevy_replicon = { version = "0.40", default-features = false }
+bevy_replicon = { version = "0.41", default-features = false }
 bevy_renet2 = { path = "../bevy_renet2", version = "0.15.0", default-features = false }
-bevy = { version = "0.18", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_log"] }
 
 [dev-dependencies]
 clap = { version = "4.1", features = ["derive"] }
 bevy_renet2 = { path = "../bevy_renet2", version = "0.15.0", features = [
   "native_transport",
 ] }
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
   "bevy_gizmos",
   "bevy_state",
   "bevy_text",

--- a/bevy_replicon_renet2/examples/simple_box.rs
+++ b/bevy_replicon_renet2/examples/simple_box.rs
@@ -85,7 +85,7 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
             commands.spawn((
                 Text::new("Server"),
                 TextFont {
-                    font_size: 30.0,
+                    font_size: FontSize::Px(30.0),
                     ..Default::default()
                 },
                 TextColor::WHITE,
@@ -118,7 +118,7 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>, channels: Res<RepliconChannel
             commands.spawn((
                 Text(format!("Client: {client_id}")),
                 TextFont {
-                    font_size: 30.0,
+                    font_size: FontSize::Px(30.0),
                     ..default()
                 },
                 TextColor::WHITE,

--- a/bevy_replicon_renet2/examples/tic_tac_toe.rs
+++ b/bevy_replicon_renet2/examples/tic_tac_toe.rs
@@ -228,7 +228,7 @@ fn setup_ui(mut commands: Commands, symbol_font: Res<SymbolFont>) {
                     children![(
                         Text::default(),
                         TextFont {
-                            font_size: FONT_SIZE,
+                            font_size: FontSize::Px(FONT_SIZE),
                             ..Default::default()
                         },
                         TextColor(TEXT_COLOR),
@@ -236,8 +236,8 @@ fn setup_ui(mut commands: Commands, symbol_font: Res<SymbolFont>) {
                         children![(
                             TextSpan::default(),
                             TextFont {
-                                font: symbol_font.0.clone(),
-                                font_size: FONT_SIZE,
+                                font: symbol_font.0.clone().into(),
+                                font_size: FontSize::Px(FONT_SIZE),
                                 ..Default::default()
                             },
                             TextColor(TEXT_COLOR),
@@ -317,8 +317,8 @@ fn init_symbols(
     commands.entity(add.entity).remove::<Interaction>().with_child((
         Text::new(symbol.glyph()),
         TextFont {
-            font: symbol_font.0.clone(),
-            font_size: 65.0,
+            font: symbol_font.0.clone().into(),
+            font_size: FontSize::Px(65.0),
             ..Default::default()
         },
         TextColor(symbol.color()),

--- a/bevy_replicon_renet2/src/client/plugin.rs
+++ b/bevy_replicon_renet2/src/client/plugin.rs
@@ -20,7 +20,7 @@ impl Plugin for RepliconRenetClientPlugin {
                     set_connected.run_if(
                         // Ensure we transition from "connecting" to "connected,"
                         // even if the transport reports "connected" right away.
-                        in_state(ClientState::Connecting).and(bevy_renet2::prelude::client_connected),
+                        in_state(ClientState::Connecting).and_then(bevy_renet2::prelude::client_connected),
                     ),
                     set_disconnected.run_if(bevy_renet2::prelude::client_just_disconnected),
                     receive_packets.run_if(bevy_renet2::prelude::client_connected),

--- a/bevy_replicon_renet2/tests/netcode.rs
+++ b/bevy_replicon_renet2/tests/netcode.rs
@@ -129,7 +129,7 @@ fn server_stop() {
 
     server_app.world_mut().spawn(Replicated);
     server_app.world_mut().write_message(ToClients {
-        targets: SendTargets::Broadcast,
+        targets: SendTargets::All,
         message: Test,
     });
 

--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -13,7 +13,7 @@ netcode = ["bevy_renet2/netcode", "bevy_renet2/native_transport"]
 steam = ["bevy_renet2/steam", "dep:steamworks"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_pbr",
@@ -28,7 +28,7 @@ bevy = { version = "0.18", default-features = false, features = [
 bevy_renet2 = { path = "../bevy_renet2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
-bevy_egui = "0.39"
+bevy_egui = "0.41"
 renet2_visualizer = { path = "../renet2_visualizer", features = ["bevy"] }
 fastrand = "2.0"
 steamworks = { version = "0.13", optional = true }

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -100,7 +100,7 @@ fn add_steam_network(app: &mut App) {
 
     app.configure_sets(Update, Connected.run_if(client_connected));
 
-    app.insert_non_send_resource(steam_client.clone());
+    app.insert_non_send(steam_client.clone());
     fn steam_callbacks(client: NonSend<Client>) {
         client.run_callbacks();
     }
@@ -135,7 +135,6 @@ fn main() {
     app.add_message::<PlayerCommand>();
 
     app.insert_resource(ClientLobby::default());
-    app.insert_resource(PlayerInput::default());
     app.insert_resource(NetworkMapping::default());
 
     app.add_systems(Update, (player_input, camera_follow, update_target_system));
@@ -146,10 +145,14 @@ fn main() {
 
     app.insert_resource(RenetClientVisualizer::<200>::new(RenetVisualizerStyle::default()));
 
-    app.add_systems(Startup, (setup_level, setup_camera, setup_target));
+    app.add_systems(Startup, (setup_level, setup_camera, setup_target, setup_player_input));
     app.add_systems(EguiPrimaryContextPass, update_visualizer_system);
 
     app.run();
+}
+
+fn setup_player_input(mut commands: Commands) {
+    commands.spawn(PlayerInput::default());
 }
 
 fn update_visualizer_system(
@@ -170,7 +173,7 @@ fn update_visualizer_system(
 
 fn player_input(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut player_input: ResMut<PlayerInput>,
+    mut player_input: Single<&mut PlayerInput>,
     mouse_button_input: Res<ButtonInput<MouseButton>>,
     target_query: Query<&Transform, With<Target>>,
     mut player_commands: MessageWriter<PlayerCommand>,
@@ -188,7 +191,7 @@ fn player_input(
     }
 }
 
-fn client_send_input(player_input: Res<PlayerInput>, mut client: ResMut<RenetClient>) {
+fn client_send_input(player_input: Single<&PlayerInput>, mut client: ResMut<RenetClient>) {
     let input_message = bincode::serialize(&*player_input).unwrap();
 
     client.send_message(ClientChannel::Input, input_message);

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -72,7 +72,7 @@ fn add_steam_network(app: &mut App) {
     app.add_plugins(SteamServerPlugin);
     app.insert_resource(server);
     app.insert_resource(transport);
-    app.insert_non_send_resource(steam_client.clone());
+    app.insert_non_send(steam_client.clone());
 
     fn steam_callbacks(client: NonSend<Client>) {
         client.run_callbacks();

--- a/demo_bevy/src/lib.rs
+++ b/demo_bevy/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Player {
     pub id: ClientId,
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Component, Resource)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Component)]
 pub struct PlayerInput {
     pub up: bool,
     pub down: bool,
@@ -131,7 +131,7 @@ pub fn setup_level(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut
     // light
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform {

--- a/demo_chat/Cargo.toml
+++ b/demo_chat/Cargo.toml
@@ -11,7 +11,7 @@ renet2_netcode = { path = "../renet2_netcode", features = [
   "serde",
 ] }
 renet2_visualizer = { path = "../renet2_visualizer" }
-eframe = "0.33"
+eframe = "0.35"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 log = { version = "0.4", features = ["std"] }

--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -53,19 +53,19 @@ impl Default for ChatApp {
 }
 
 impl ChatApp {
-    pub fn draw(&mut self, ctx: &egui::Context) {
+    pub fn draw(&mut self, ui: &mut egui::Ui) {
         match &mut self.state {
             AppState::MainScreen => {
-                draw_main_screen(&mut self.ui_state, &mut self.state, ctx);
+                draw_main_screen(&mut self.ui_state, &mut self.state, ui);
             }
-            AppState::ClientChat { client, .. } if client.is_connecting() => draw_loader(ctx),
+            AppState::ClientChat { client, .. } if client.is_connecting() => draw_loader(ui),
             AppState::ClientChat { usernames, .. } => {
                 let usernames = usernames.clone();
-                draw_chat(&mut self.ui_state, &mut self.state, usernames, ctx);
+                draw_chat(&mut self.ui_state, &mut self.state, usernames, ui);
             }
             AppState::HostChat { chat_server } => {
                 let usernames = chat_server.usernames.clone();
-                draw_chat(&mut self.ui_state, &mut self.state, usernames, ctx);
+                draw_chat(&mut self.ui_state, &mut self.state, usernames, ui);
             }
         }
     }

--- a/demo_chat/src/main.rs
+++ b/demo_chat/src/main.rs
@@ -41,10 +41,13 @@ impl Message {
 }
 
 impl App for ChatApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.draw(ctx);
+    fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.update_chat();
         ctx.request_repaint();
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        self.draw(ui);
     }
 }
 

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -18,8 +18,8 @@ use crate::{
 };
 use crate::{ClientMessages, Username, PROTOCOL_ID};
 
-pub fn draw_loader(ctx: &egui::Context) {
-    egui::CentralPanel::default().show(ctx, |ui| {
+pub fn draw_loader(ui: &mut Ui) {
+    egui::CentralPanel::default().show(ui, |ui| {
         // Taken from egui progress bar widget
         let n_points = 20;
         let time = ui.input(|input| input.time);
@@ -73,8 +73,8 @@ pub fn draw_host_commands(ui: &mut Ui, chat_server: &mut ChatServer) {
     });
 }
 
-pub fn draw_main_screen(ui_state: &mut UiState, state: &mut AppState, ctx: &egui::Context) {
-    egui::CentralPanel::default().show(ctx, |ui| {
+pub fn draw_main_screen(ui_state: &mut UiState, state: &mut AppState, ui: &mut Ui) {
+    egui::CentralPanel::default().show(ui, |ui| {
         egui::Area::new("buttons".into())
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .show(ui.ctx(), |ui| {
@@ -136,23 +136,25 @@ pub fn draw_main_screen(ui_state: &mut UiState, state: &mut AppState, ctx: &egui
     });
 }
 
-pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<ClientId, String>, ctx: &egui::Context) {
+pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<ClientId, String>, ui: &mut Ui) {
+    let ctx = ui.ctx().clone();
+
     if ui_state.show_network_info {
         match state {
             AppState::ClientChat { visualizer, .. } => {
-                visualizer.show_window(ctx);
+                visualizer.show_window(&ctx);
             }
             AppState::HostChat { ref mut chat_server } => {
-                chat_server.visualizer.show_window(ctx);
+                chat_server.visualizer.show_window(&ctx);
             }
             _ => {}
         }
     }
 
-    let exit = egui::SidePanel::right("right_panel")
-        .min_width(200.0)
-        .default_width(200.0)
-        .show(ctx, |ui| {
+    let exit = egui::Panel::right("right_panel")
+        .min_size(200.0)
+        .default_size(200.0)
+        .show(ui, |ui| {
             ui.checkbox(&mut ui_state.show_network_info, "Show Network Graphs");
 
             if let AppState::HostChat { ref mut chat_server } = state {
@@ -171,7 +173,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
                 }
             });
 
-            let exit = ui.with_layout(Layout::bottom_up(eframe::emath::Align::Center).with_cross_justify(true), |ui| {
+            let exit = ui.with_layout(Layout::bottom_up(egui::Align::Center).with_cross_justify(true), |ui| {
                 ui.button("Exit").clicked()
             });
 
@@ -193,7 +195,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
         return;
     }
 
-    egui::TopBottomPanel::bottom("text_editor").show(ctx, |ui| {
+    egui::Panel::bottom("text_editor").show(ui, |ui| {
         let send_message = ui.horizontal(|ui| {
             let response = ui.text_edit_singleline(&mut ui_state.text_input);
 
@@ -226,7 +228,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
         }
     });
 
-    egui::CentralPanel::default().show(ctx, |ui| {
+    egui::CentralPanel::default().show(ui, |ui| {
         egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
             .id_salt("client_list_scroll")

--- a/renet2/Cargo.toml
+++ b/renet2/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 bevy = ["dep:bevy_ecs"]
 
 [dependencies]
-bevy_ecs = { version = "0.18", optional = true }
+bevy_ecs = { version = "0.19", optional = true }
 bytes = "1.1"
 log = "0.4"
 octets = "0.3"

--- a/renet2_netcode/Cargo.toml
+++ b/renet2_netcode/Cargo.toml
@@ -111,7 +111,7 @@ renetcode2 = { path = "../renetcode2", version = "0.15.0" }
 renet2 = { path = "../renet2", version = "0.15.0" }
 hmac-sha256 = { version = "1.1" }
 url = { version = "2.4" }
-bevy_ecs = { version = "0.18", optional = true }
+bevy_ecs = { version = "0.19", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # In-memory transport socket

--- a/renet2_netcode/src/websocket_socket/server/socket.rs
+++ b/renet2_netcode/src/websocket_socket/server/socket.rs
@@ -303,6 +303,7 @@ impl WebSocketServer {
         // TODO: this is a multistep process that continues after receiving a Request. We would rather
         // pause to validate the URI before continuing, but tungstenite does not support that workflow.
         // Might need to use axum instead.
+        #[allow(clippy::result_large_err, reason = "this is from a tungstenite handshake callback closure")]
         let callback = move |req: &Request, res: Response| {
             let uri = req.uri().clone();
             uri_sender.try_send(uri).ok();

--- a/renet2_setup/Cargo.toml
+++ b/renet2_setup/Cargo.toml
@@ -23,7 +23,7 @@ renet2_netcode = { path = "../renet2_netcode", version = "0.15.0", optional = tr
   "serde",
 ] }
 
-bevy_ecs = { version = "0.18", optional = true }
+bevy_ecs = { version = "0.19", optional = true }
 enfync = { version = "0.1", default-features = false, optional = true }
 rustls = { version = "0.23", optional = true }
 rustls-pki-types = { version = "1.7", optional = true }

--- a/renet2_steam/Cargo.toml
+++ b/renet2_steam/Cargo.toml
@@ -20,7 +20,7 @@ bevy = ["dep:bevy_ecs"]
 renet2 = { path = "../renet2", version = "0.15.0" }
 steamworks = "0.13"
 log = "0.4.19"
-bevy_ecs = { version = "0.18", optional = true }
+bevy_ecs = { version = "0.19", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/renet2_visualizer/Cargo.toml
+++ b/renet2_visualizer/Cargo.toml
@@ -17,5 +17,5 @@ bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 renet2 = { path = "../renet2", version = "0.15.0" }
-egui = "0.33"
-bevy_ecs = { version = "0.18", optional = true }
+egui = "0.35"
+bevy_ecs = { version = "0.19", optional = true }

--- a/renet2_visualizer/src/lib.rs
+++ b/renet2_visualizer/src/lib.rs
@@ -371,16 +371,13 @@ fn show_graph(
         let text_pos = rect.right_center() + vec2(spacing_x / 2.0, -galley.size().y / 2.);
         ui.painter().with_clip_rect(outer_rect).galley(text_pos, galley, style.text_color);
 
-        let body = Shape::Rect(RectShape {
+        let body = Shape::Rect(RectShape::new(
             rect,
-            corner_radius: CornerRadius::ZERO,
-            fill: Rgba::TRANSPARENT.into(),
-            stroke: style.rectangle_stroke,
-            blur_width: 0.,
-            round_to_pixels: None,
-            stroke_kind: egui::StrokeKind::Inside,
-            brush: None,
-        });
+            CornerRadius::ZERO,
+            Rgba::TRANSPARENT,
+            style.rectangle_stroke,
+            egui::StrokeKind::Inside,
+        ));
         ui.painter().add(body);
         let init_point = rect.left_bottom();
 


### PR DESCRIPTION
Changes:

- bumped from bevy 0.18 to 0.19
- updated dependencies to bevy 0.19 versions where relevant
- updated code to use to use latest dependencies properly
- updated examples to use bevy 0.19. Mostly handle resources differently + Single<T>